### PR TITLE
Use legacy linux prop instead of linux_glibc

### DIFF
--- a/dist/Android.bp
+++ b/dist/Android.bp
@@ -42,7 +42,7 @@ cc_defaults {
     ],
 
     target: {
-        linux_glibc: {
+        linux: {
             cflags: ["-DHAVE_POSIX_FALLOCATE=1"],
         },
     },


### PR DESCRIPTION
Due to Oreo soong. linux_glibc support was brought in Pie releases.